### PR TITLE
1.49.0

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -5,7 +5,7 @@ import { stringify } from "jsr:@std/yaml@^0.221/stringify";
 // Bump this number when you want to purge the cache.
 // Note: the tools/release/01_bump_crate_versions.ts script will update this version
 // automatically via regex, so ensure that this line maintains this format.
-const cacheVersion = 19;
+const cacheVersion = 20;
 
 const ubuntuX86Runner = "ubuntu-22.04";
 const ubuntuARMRunner = "ubicloud-standard-16-arm";

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,8 +294,8 @@ jobs:
           path: |-
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
-          key: '19-cargo-home-${{ matrix.os }}-${{ matrix.arch }}-${{ hashFiles(''Cargo.lock'') }}'
-          restore-keys: '19-cargo-home-${{ matrix.os }}-${{ matrix.arch }}'
+          key: '20-cargo-home-${{ matrix.os }}-${{ matrix.arch }}-${{ hashFiles(''Cargo.lock'') }}'
+          restore-keys: '20-cargo-home-${{ matrix.os }}-${{ matrix.arch }}'
         if: '!(matrix.skip)'
       - name: Restore cache build output (PR)
         uses: actions/cache/restore@v4
@@ -308,7 +308,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: never_saved
-          restore-keys: '19-cargo-target-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ matrix.job }}-'
+          restore-keys: '20-cargo-target-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ matrix.job }}-'
       - name: Apply and update mtime cache
         if: '!(matrix.skip) && (!startsWith(github.ref, ''refs/tags/''))'
         uses: ./.github/mtime_cache
@@ -492,7 +492,7 @@ jobs:
             !./target/*/gn_out
             !./target/*/*.zip
             !./target/*/*.tar.gz
-          key: '19-cargo-target-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ matrix.job }}-${{ github.sha }}'
+          key: '20-cargo-target-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ matrix.job }}-${{ github.sha }}'
   post-build:
     name: post-build
     runs-on: ubuntu-22.04

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1159,7 +1159,7 @@ dependencies = [
 
 [[package]]
 name = "deno"
-version = "1.48.0"
+version = "1.49.0"
 dependencies = [
  "anstream",
  "async-trait",
@@ -1328,7 +1328,7 @@ dependencies = [
 
 [[package]]
 name = "deno_bench_util"
-version = "0.165.0"
+version = "0.166.0"
 dependencies = [
  "bencher",
  "deno_core",
@@ -1337,7 +1337,7 @@ dependencies = [
 
 [[package]]
 name = "deno_broadcast_channel"
-version = "0.165.0"
+version = "0.166.0"
 dependencies = [
  "async-trait",
  "deno_core",
@@ -1347,7 +1347,7 @@ dependencies = [
 
 [[package]]
 name = "deno_cache"
-version = "0.103.0"
+version = "0.104.0"
 dependencies = [
  "async-trait",
  "deno_core",
@@ -1377,7 +1377,7 @@ dependencies = [
 
 [[package]]
 name = "deno_canvas"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "deno_core",
  "deno_webgpu",
@@ -1410,7 +1410,7 @@ dependencies = [
 
 [[package]]
 name = "deno_console"
-version = "0.171.0"
+version = "0.172.0"
 dependencies = [
  "deno_core",
 ]
@@ -1455,7 +1455,7 @@ checksum = "a13951ea98c0a4c372f162d669193b4c9d991512de9f2381dd161027f34b26b1"
 
 [[package]]
 name = "deno_cron"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1467,7 +1467,7 @@ dependencies = [
 
 [[package]]
 name = "deno_crypto"
-version = "0.185.0"
+version = "0.186.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "deno_fetch"
-version = "0.195.0"
+version = "0.196.0"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -1559,7 +1559,7 @@ dependencies = [
 
 [[package]]
 name = "deno_ffi"
-version = "0.158.0"
+version = "0.159.0"
 dependencies = [
  "deno_core",
  "deno_permissions",
@@ -1576,7 +1576,7 @@ dependencies = [
 
 [[package]]
 name = "deno_fs"
-version = "0.81.0"
+version = "0.82.0"
 dependencies = [
  "async-trait",
  "base32",
@@ -1625,7 +1625,7 @@ dependencies = [
 
 [[package]]
 name = "deno_http"
-version = "0.169.0"
+version = "0.170.0"
 dependencies = [
  "async-compression",
  "async-trait",
@@ -1664,7 +1664,7 @@ dependencies = [
 
 [[package]]
 name = "deno_io"
-version = "0.81.0"
+version = "0.82.0"
 dependencies = [
  "async-trait",
  "deno_core",
@@ -1685,7 +1685,7 @@ dependencies = [
 
 [[package]]
 name = "deno_kv"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1754,7 +1754,7 @@ dependencies = [
 
 [[package]]
 name = "deno_napi"
-version = "0.102.0"
+version = "0.103.0"
 dependencies = [
  "deno_core",
  "deno_permissions",
@@ -1776,7 +1776,7 @@ dependencies = [
 
 [[package]]
 name = "deno_net"
-version = "0.163.0"
+version = "0.164.0"
 dependencies = [
  "deno_core",
  "deno_permissions",
@@ -1792,7 +1792,7 @@ dependencies = [
 
 [[package]]
 name = "deno_node"
-version = "0.108.0"
+version = "0.109.0"
 dependencies = [
  "aead-gcm-stream",
  "aes",
@@ -1929,7 +1929,7 @@ dependencies = [
 
 [[package]]
 name = "deno_permissions"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "deno_core",
  "deno_terminal 0.2.0",
@@ -1945,7 +1945,7 @@ dependencies = [
 
 [[package]]
 name = "deno_runtime"
-version = "0.180.0"
+version = "0.181.0"
 dependencies = [
  "deno_ast",
  "deno_broadcast_channel",
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "deno_tls"
-version = "0.158.0"
+version = "0.159.0"
 dependencies = [
  "deno_core",
  "deno_native_certs",
@@ -2106,7 +2106,7 @@ dependencies = [
 
 [[package]]
 name = "deno_url"
-version = "0.171.0"
+version = "0.172.0"
 dependencies = [
  "deno_bench_util",
  "deno_console",
@@ -2117,7 +2117,7 @@ dependencies = [
 
 [[package]]
 name = "deno_web"
-version = "0.202.0"
+version = "0.203.0"
 dependencies = [
  "async-trait",
  "base64-simd 0.8.0",
@@ -2138,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "deno_webgpu"
-version = "0.138.0"
+version = "0.139.0"
 dependencies = [
  "deno_core",
  "raw-window-handle",
@@ -2150,7 +2150,7 @@ dependencies = [
 
 [[package]]
 name = "deno_webidl"
-version = "0.171.0"
+version = "0.172.0"
 dependencies = [
  "deno_bench_util",
  "deno_core",
@@ -2158,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "deno_websocket"
-version = "0.176.0"
+version = "0.177.0"
 dependencies = [
  "bytes",
  "deno_core",
@@ -2179,7 +2179,7 @@ dependencies = [
 
 [[package]]
 name = "deno_webstorage"
-version = "0.166.0"
+version = "0.167.0"
 dependencies = [
  "deno_core",
  "deno_web",
@@ -4565,7 +4565,7 @@ dependencies = [
 
 [[package]]
 name = "napi_sym"
-version = "0.101.0"
+version = "0.102.0"
 dependencies = [
  "quote",
  "serde",
@@ -4634,7 +4634,7 @@ dependencies = [
 
 [[package]]
 name = "node_resolver"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,14 +47,14 @@ repository = "https://github.com/unyt-org/deno"
 deno_ast = { version = "=0.42.0", features = ["transpiling"] }
 deno_core = { version = "0.311.0" }
 
-deno_bench_util = { version = "0.165.0", path = "./bench_util" }
+deno_bench_util = { version = "0.166.0", path = "./bench_util" }
 deno_lockfile = "=0.23.0"
 deno_media_type = { version = "0.1.4", features = ["module_specifier"] }
-deno_permissions = { version = "0.31.0", path = "./runtime/permissions" }
-deno_runtime = { version = "0.180.0", path = "./runtime" }
+deno_permissions = { version = "0.32.0", path = "./runtime/permissions" }
+deno_runtime = { version = "0.181.0", path = "./runtime" }
 deno_semver = "=0.5.13"
 deno_terminal = "0.2.0"
-napi_sym = { version = "0.101.0", path = "./cli/napi/sym" }
+napi_sym = { version = "0.102.0", path = "./cli/napi/sym" }
 test_util = { package = "test_server", path = "./tests/util/server" }
 
 denokv_proto = "0.8.1"
@@ -63,29 +63,29 @@ denokv_remote = "0.8.1"
 denokv_sqlite = { default-features = false, version = "0.8.2" }
 
 # exts
-deno_broadcast_channel = { version = "0.165.0", path = "./ext/broadcast_channel" }
-deno_cache = { version = "0.103.0", path = "./ext/cache" }
-deno_canvas = { version = "0.40.0", path = "./ext/canvas" }
-deno_console = { version = "0.171.0", path = "./ext/console" }
-deno_cron = { version = "0.51.0", path = "./ext/cron" }
-deno_crypto = { version = "0.185.0", path = "./ext/crypto" }
-deno_fetch = { version = "0.195.0", path = "./ext/fetch" }
-deno_ffi = { version = "0.158.0", path = "./ext/ffi" }
-deno_fs = { version = "0.81.0", path = "./ext/fs" }
-deno_http = { version = "0.169.0", path = "./ext/http" }
-deno_io = { version = "0.81.0", path = "./ext/io" }
-deno_kv = { version = "0.79.0", path = "./ext/kv" }
-deno_napi = { version = "0.102.0", path = "./ext/napi" }
-deno_net = { version = "0.163.0", path = "./ext/net" }
-deno_node = { version = "0.108.0", path = "./ext/node" }
-deno_tls = { version = "0.158.0", path = "./ext/tls" }
-deno_url = { version = "0.171.0", path = "./ext/url" }
-deno_web = { version = "0.202.0", path = "./ext/web" }
-deno_webgpu = { version = "0.138.0", path = "./ext/webgpu" }
-deno_webidl = { version = "0.171.0", path = "./ext/webidl" }
-deno_websocket = { version = "0.176.0", path = "./ext/websocket" }
-deno_webstorage = { version = "0.166.0", path = "./ext/webstorage" }
-node_resolver = { version = "0.10.0", path = "./ext/node_resolver" }
+deno_broadcast_channel = { version = "0.166.0", path = "./ext/broadcast_channel" }
+deno_cache = { version = "0.104.0", path = "./ext/cache" }
+deno_canvas = { version = "0.41.0", path = "./ext/canvas" }
+deno_console = { version = "0.172.0", path = "./ext/console" }
+deno_cron = { version = "0.52.0", path = "./ext/cron" }
+deno_crypto = { version = "0.186.0", path = "./ext/crypto" }
+deno_fetch = { version = "0.196.0", path = "./ext/fetch" }
+deno_ffi = { version = "0.159.0", path = "./ext/ffi" }
+deno_fs = { version = "0.82.0", path = "./ext/fs" }
+deno_http = { version = "0.170.0", path = "./ext/http" }
+deno_io = { version = "0.82.0", path = "./ext/io" }
+deno_kv = { version = "0.80.0", path = "./ext/kv" }
+deno_napi = { version = "0.103.0", path = "./ext/napi" }
+deno_net = { version = "0.164.0", path = "./ext/net" }
+deno_node = { version = "0.109.0", path = "./ext/node" }
+deno_tls = { version = "0.159.0", path = "./ext/tls" }
+deno_url = { version = "0.172.0", path = "./ext/url" }
+deno_web = { version = "0.203.0", path = "./ext/web" }
+deno_webgpu = { version = "0.139.0", path = "./ext/webgpu" }
+deno_webidl = { version = "0.172.0", path = "./ext/webidl" }
+deno_websocket = { version = "0.177.0", path = "./ext/websocket" }
+deno_webstorage = { version = "0.167.0", path = "./ext/webstorage" }
+node_resolver = { version = "0.11.0", path = "./ext/node_resolver" }
 
 aes = "=0.8.3"
 anyhow = "1.0.57"

--- a/Releases.md
+++ b/Releases.md
@@ -6,6 +6,10 @@ https://github.com/denoland/deno/releases
 We also have one-line install commands at:
 https://github.com/denoland/deno_install
 
+### 1.49.0 / 2024.09.30
+
+- Merge pull request #13 from unyt-org/release_1_48.0
+
 ### 1.47.2 / 2024.09.10
 
 - Add deno_uix logo

--- a/bench_util/Cargo.toml
+++ b/bench_util/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_bench_util"
-version = "0.165.0"
+version = "0.166.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno"
-version = "1.48.0"
+version = "1.49.0"
 authors.workspace = true
 default-run = "deno"
 edition.workspace = true

--- a/cli/napi/sym/Cargo.toml
+++ b/cli/napi/sym/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "napi_sym"
-version = "0.101.0"
+version = "0.102.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/broadcast_channel/Cargo.toml
+++ b/ext/broadcast_channel/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_broadcast_channel"
-version = "0.165.0"
+version = "0.166.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/cache/Cargo.toml
+++ b/ext/cache/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_cache"
-version = "0.103.0"
+version = "0.104.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/canvas/Cargo.toml
+++ b/ext/canvas/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_canvas"
-version = "0.40.0"
+version = "0.41.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/console/Cargo.toml
+++ b/ext/console/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_console"
-version = "0.171.0"
+version = "0.172.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/cron/Cargo.toml
+++ b/ext/cron/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_cron"
-version = "0.51.0"
+version = "0.52.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/crypto/Cargo.toml
+++ b/ext/crypto/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_crypto"
-version = "0.185.0"
+version = "0.186.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/fetch/Cargo.toml
+++ b/ext/fetch/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_fetch"
-version = "0.195.0"
+version = "0.196.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/ffi/Cargo.toml
+++ b/ext/ffi/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_ffi"
-version = "0.158.0"
+version = "0.159.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/fs/Cargo.toml
+++ b/ext/fs/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_fs"
-version = "0.81.0"
+version = "0.82.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/http/Cargo.toml
+++ b/ext/http/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_http"
-version = "0.169.0"
+version = "0.170.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/io/Cargo.toml
+++ b/ext/io/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_io"
-version = "0.81.0"
+version = "0.82.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/kv/Cargo.toml
+++ b/ext/kv/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_kv"
-version = "0.79.0"
+version = "0.80.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/napi/Cargo.toml
+++ b/ext/napi/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_napi"
-version = "0.102.0"
+version = "0.103.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/net/Cargo.toml
+++ b/ext/net/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_net"
-version = "0.163.0"
+version = "0.164.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/node/Cargo.toml
+++ b/ext/node/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_node"
-version = "0.108.0"
+version = "0.109.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/node_resolver/Cargo.toml
+++ b/ext/node_resolver/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "node_resolver"
-version = "0.10.0"
+version = "0.11.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/tls/Cargo.toml
+++ b/ext/tls/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_tls"
-version = "0.158.0"
+version = "0.159.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/url/Cargo.toml
+++ b/ext/url/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_url"
-version = "0.171.0"
+version = "0.172.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/web/Cargo.toml
+++ b/ext/web/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_web"
-version = "0.202.0"
+version = "0.203.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/webgpu/Cargo.toml
+++ b/ext/webgpu/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_webgpu"
-version = "0.138.0"
+version = "0.139.0"
 authors = ["the Deno authors"]
 edition.workspace = true
 license = "MIT"

--- a/ext/webidl/Cargo.toml
+++ b/ext/webidl/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_webidl"
-version = "0.171.0"
+version = "0.172.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/websocket/Cargo.toml
+++ b/ext/websocket/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_websocket"
-version = "0.176.0"
+version = "0.177.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/webstorage/Cargo.toml
+++ b/ext/webstorage/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_webstorage"
-version = "0.166.0"
+version = "0.167.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_runtime"
-version = "0.180.0"
+version = "0.181.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/runtime/permissions/Cargo.toml
+++ b/runtime/permissions/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_permissions"
-version = "0.31.0"
+version = "0.32.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
Bumped versions for 1.49.0

Please ensure:
- [ ] Target branch is correct (`vX.XX` if a patch release, `main` if minor)
- [ ] Crate versions are bumped correctly
- [ ] Releases.md is updated correctly (think relevancy and remove reverts)

To make edits to this PR:
```shell
git fetch upstream release_1_49.0 && git checkout -b release_1_49.0 upstream/release_1_49.0
```

cc @jonasstrehle